### PR TITLE
Proposal - Policy Updates

### DIFF
--- a/MACOS/NativeImport/MacOS - OIB - Defender Antivirus - D - Antivirus Configuration - v1.0.json
+++ b/MACOS/NativeImport/MacOS - OIB - Defender Antivirus - D - Antivirus Configuration - v1.0.json
@@ -1,16 +1,16 @@
 ﻿{
   "@odata.context": "https://graph.microsoft.com/beta/$metadata#deviceManagement/configurationPolicies/$entity",
-  "createdDateTime": "2024-08-22T18:53:05.2105824Z",
+  "createdDateTime": "2024-08-27T14:33:05.2998609Z",
   "creationSource": null,
   "description": "",
-  "lastModifiedDateTime": "2024-08-22T18:53:05.2105824Z",
-  "name": "MacOS - OIB - Defender Antivirus - D - Antivirus Configuration - v1.0",
+  "lastModifiedDateTime": "2024-08-29T12:42:48.7023946Z",
+  "name": "MacOS - OIB - Defender Antivirus - D - Antivirus Configuration - v1.1",
   "platforms": "macOS",
   "priorityMetaData": null,
   "roleScopeTagIds": ["0"],
   "settingCount": 19,
   "technologies": "mdm,appleRemoteManagement",
-  "id": "4eb28b0e-9e70-4b21-9b10-8058a8ea5b47",
+  "id": "07c64b03-5f7c-4cfc-b3d0-aae1bbbe0f7f",
   "templateReference": {
     "templateId": "",
     "templateFamily": "none",
@@ -346,7 +346,7 @@
         "settingInstanceTemplateReference": null,
         "choiceSettingValue": {
           "settingValueTemplateReference": null,
-          "value": "com.apple.managedclient.preferences_hidestatusmenuicon_true",
+          "value": "com.apple.managedclient.preferences_hidestatusmenuicon_false",
           "children": []
         }
       }

--- a/MACOS/NativeImport/MacOS - OIB - Device Security - D - Accounts and Login - v1.0.json
+++ b/MACOS/NativeImport/MacOS - OIB - Device Security - D - Accounts and Login - v1.0.json
@@ -1,16 +1,16 @@
 ﻿{
   "@odata.context": "https://graph.microsoft.com/beta/$metadata#deviceManagement/configurationPolicies/$entity",
-  "createdDateTime": "2024-08-17T16:14:09.1697475Z",
+  "createdDateTime": "2024-08-27T14:33:05.8459213Z",
   "creationSource": null,
   "description": "",
-  "lastModifiedDateTime": "2024-08-17T16:14:09.1697475Z",
-  "name": "MacOS - OIB - Device Security - D - Accounts and Login - v1.0",
+  "lastModifiedDateTime": "2024-08-29T12:50:48.0209403Z",
+  "name": "MacOS - OIB - Device Security - D - Accounts and Login - v1.1",
   "platforms": "macOS",
   "priorityMetaData": null,
   "roleScopeTagIds": ["0"],
   "settingCount": 3,
   "technologies": "mdm,appleRemoteManagement",
-  "id": "54374899-e5b5-4f7b-b20d-d2121deac3a5",
+  "id": "d7cdc5f6-dd8f-4ea7-9f8c-95aa7f035f3f",
   "templateReference": {
     "templateId": "",
     "templateFamily": "none",
@@ -79,7 +79,7 @@
                 "settingInstanceTemplateReference": null,
                 "choiceSettingValue": {
                   "settingValueTemplateReference": null,
-                  "value": "com.apple.loginwindow_hideadminusers_true",
+                  "value": "com.apple.loginwindow_hideadminusers_false",
                   "children": []
                 }
               }

--- a/MACOS/NativeImport/MacOS - OIB - Disk Encryption - D - FileVault - v1.0.json
+++ b/MACOS/NativeImport/MacOS - OIB - Disk Encryption - D - FileVault - v1.0.json
@@ -1,16 +1,16 @@
 ﻿{
   "@odata.context": "https://graph.microsoft.com/beta/$metadata#deviceManagement/configurationPolicies/$entity",
-  "createdDateTime": "2024-08-17T14:45:17.6736148Z",
+  "createdDateTime": "2024-08-27T14:33:06.4056266Z",
   "creationSource": null,
   "description": "",
-  "lastModifiedDateTime": "2024-08-22T18:55:46.8576861Z",
-  "name": "MacOS - OIB - Disk Encryption - D - FileVault - v1.0",
+  "lastModifiedDateTime": "2024-08-29T12:13:58.8294917Z",
+  "name": "MacOS - OIB - Disk Encryption - D - FileVault - v1.1",
   "platforms": "macOS",
   "priorityMetaData": null,
   "roleScopeTagIds": ["0"],
   "settingCount": 3,
   "technologies": "mdm,appleRemoteManagement",
-  "id": "31fb9b3e-e1d0-4c8b-afdf-6d7a1ceb1b82",
+  "id": "3828f80f-4e13-471d-bfda-52446dc1379c",
   "templateReference": {
     "templateId": "",
     "templateFamily": "none",
@@ -30,16 +30,6 @@
             "children": [
               {
                 "@odata.type": "#microsoft.graph.deviceManagementConfigurationChoiceSettingInstance",
-                "settingDefinitionId": "com.apple.mcx.filevault2_defer",
-                "settingInstanceTemplateReference": null,
-                "choiceSettingValue": {
-                  "settingValueTemplateReference": null,
-                  "value": "com.apple.mcx.filevault2_defer_true",
-                  "children": []
-                }
-              },
-              {
-                "@odata.type": "#microsoft.graph.deviceManagementConfigurationChoiceSettingInstance",
                 "settingDefinitionId": "com.apple.mcx.filevault2_enable",
                 "settingInstanceTemplateReference": null,
                 "choiceSettingValue": {
@@ -55,6 +45,16 @@
                 "choiceSettingValue": {
                   "settingValueTemplateReference": null,
                   "value": "com.apple.mcx.filevault2_forceenableinsetupassistant_true",
+                  "children": []
+                }
+              },
+              {
+                "@odata.type": "#microsoft.graph.deviceManagementConfigurationChoiceSettingInstance",
+                "settingDefinitionId": "com.apple.mcx.filevault2_recoverykeyrotationinmonths",
+                "settingInstanceTemplateReference": null,
+                "choiceSettingValue": {
+                  "settingValueTemplateReference": null,
+                  "value": "com.apple.mcx.filevault2_recoverykeyrotationinmonths_6",
                   "children": []
                 }
               }

--- a/MACOS/NativeImport/MacOS - OIB - Firewall - D - Gatekeeper - v1.0.json
+++ b/MACOS/NativeImport/MacOS - OIB - Firewall - D - Gatekeeper - v1.0.json
@@ -1,16 +1,16 @@
 ﻿{
   "@odata.context": "https://graph.microsoft.com/beta/$metadata#deviceManagement/configurationPolicies/$entity",
-  "createdDateTime": "2024-08-22T18:43:46.9263481Z",
+  "createdDateTime": "2024-08-27T14:33:06.635648Z",
   "creationSource": null,
   "description": "",
-  "lastModifiedDateTime": "2024-08-22T18:43:46.9263481Z",
-  "name": "MacOS - OIB - Firewall - D - Gatekeeper - v1.0",
+  "lastModifiedDateTime": "2024-08-29T12:47:21.4955625Z",
+  "name": "MacOS - OIB - Firewall - D - Gatekeeper - v1.1",
   "platforms": "macOS",
   "priorityMetaData": null,
   "roleScopeTagIds": ["0"],
   "settingCount": 2,
   "technologies": "mdm,appleRemoteManagement",
-  "id": "bd13f08e-cdb4-401a-802f-d595e000c1da",
+  "id": "542eb496-ee04-431f-8f43-c723ad18bdef",
   "templateReference": {
     "templateId": "",
     "templateFamily": "none",
@@ -34,7 +34,7 @@
                 "settingInstanceTemplateReference": null,
                 "choiceSettingValue": {
                   "settingValueTemplateReference": null,
-                  "value": "com.apple.security.firewall_blockallincoming_true",
+                  "value": "com.apple.security.firewall_blockallincoming_false",
                   "children": []
                 }
               },
@@ -89,7 +89,7 @@
                 "settingInstanceTemplateReference": null,
                 "choiceSettingValue": {
                   "settingValueTemplateReference": null,
-                  "value": "com.apple.systempolicy.control_allowidentifieddevelopers_false",
+                  "value": "com.apple.systempolicy.control_allowidentifieddevelopers_true",
                   "children": []
                 }
               },

--- a/MACOS/NativeImport/MacOS - OIB - Microsoft AutoUpdate - D - MAU Configuration - v1.0.json
+++ b/MACOS/NativeImport/MacOS - OIB - Microsoft AutoUpdate - D - MAU Configuration - v1.0.json
@@ -1,16 +1,16 @@
 ﻿{
   "@odata.context": "https://graph.microsoft.com/beta/$metadata#deviceManagement/configurationPolicies/$entity",
-  "createdDateTime": "2024-08-17T14:54:53.9814292Z",
+  "createdDateTime": "2024-08-27T14:33:06.9265378Z",
   "creationSource": null,
   "description": "",
-  "lastModifiedDateTime": "2024-08-19T14:32:58.1538595Z",
-  "name": "MacOS - OIB - Microsoft AutoUpdate - D - MAU Configuration - v1.0",
+  "lastModifiedDateTime": "2024-08-29T12:27:20.089236Z",
+  "name": "MacOS - OIB - Microsoft AutoUpdate - D - MAU Configuration - v1.1",
   "platforms": "macOS",
   "priorityMetaData": null,
   "roleScopeTagIds": ["0"],
   "settingCount": 12,
   "technologies": "mdm,appleRemoteManagement",
-  "id": "42af7e7e-8197-42d5-8661-041838c4008b",
+  "id": "e62e9f44-2843-4451-a7d5-7ad8813d1ffc",
   "templateReference": {
     "templateId": "",
     "templateFamily": "none",
@@ -161,7 +161,7 @@
         "settingInstanceTemplateReference": null,
         "choiceSettingValue": {
           "settingValueTemplateReference": null,
-          "value": "com.apple.managedclient.preferences_guardagainstappmodification_false",
+          "value": "com.apple.managedclient.preferences_guardagainstappmodification_true",
           "children": []
         }
       }
@@ -200,7 +200,7 @@
         "settingInstanceTemplateReference": null,
         "choiceSettingValue": {
           "settingValueTemplateReference": null,
-          "value": "com.apple.managedclient.preferences_channelname_0",
+          "value": "com.apple.managedclient.preferences_channelname_4",
           "children": []
         }
       }
@@ -213,7 +213,7 @@
         "settingInstanceTemplateReference": null,
         "choiceSettingValue": {
           "settingValueTemplateReference": null,
-          "value": "com.apple.managedclient.preferences_updateroptimization_0",
+          "value": "com.apple.managedclient.preferences_updateroptimization_1",
           "children": []
         }
       }

--- a/MACOS/NativeImport/MacOS - OIB - Microsoft OneDrive - D - Service and Access - v1.0.json
+++ b/MACOS/NativeImport/MacOS - OIB - Microsoft OneDrive - D - Service and Access - v1.0.json
@@ -1,16 +1,16 @@
 ﻿{
   "@odata.context": "https://graph.microsoft.com/beta/$metadata#deviceManagement/configurationPolicies/$entity",
-  "createdDateTime": "2024-08-17T14:33:42.1106733Z",
+  "createdDateTime": "2024-08-27T14:39:59.5862343Z",
   "creationSource": null,
   "description": "",
-  "lastModifiedDateTime": "2024-08-19T14:19:00.6042162Z",
-  "name": "MacOS - OIB - Microsoft OneDrive - D - Service and Access - v1.0",
+  "lastModifiedDateTime": "2024-08-29T11:56:21.9927Z",
+  "name": "MacOS - OIB - Microsoft OneDrive - D - Service and Access - v1.1",
   "platforms": "macOS",
   "priorityMetaData": null,
   "roleScopeTagIds": ["0"],
   "settingCount": 3,
   "technologies": "mdm,appleRemoteManagement",
-  "id": "7c61fc2c-14ee-42a4-ace0-1736fc031f0c",
+  "id": "4c768107-efda-4149-8697-00fe409efbb0",
   "templateReference": {
     "templateId": "",
     "templateFamily": "none",
@@ -52,7 +52,7 @@
                         "settingInstanceTemplateReference": null,
                         "choiceSettingValue": {
                           "settingValueTemplateReference": null,
-                          "value": "com.apple.servicemanagement_rules_item_ruletype_2",
+                          "value": "com.apple.servicemanagement_rules_item_ruletype_3",
                           "children": []
                         }
                       },
@@ -64,41 +64,6 @@
                           "@odata.type": "#microsoft.graph.deviceManagementConfigurationStringSettingValue",
                           "settingValueTemplateReference": null,
                           "value": "com.microsoft.OneDrive"
-                        }
-                      }
-                    ]
-                  },
-                  {
-                    "settingValueTemplateReference": null,
-                    "children": [
-                      {
-                        "@odata.type": "#microsoft.graph.deviceManagementConfigurationSimpleSettingInstance",
-                        "settingDefinitionId": "com.apple.servicemanagement_rules_item_comment",
-                        "settingInstanceTemplateReference": null,
-                        "simpleSettingValue": {
-                          "@odata.type": "#microsoft.graph.deviceManagementConfigurationStringSettingValue",
-                          "settingValueTemplateReference": null,
-                          "value": "OneDrive (VPP)"
-                        }
-                      },
-                      {
-                        "@odata.type": "#microsoft.graph.deviceManagementConfigurationChoiceSettingInstance",
-                        "settingDefinitionId": "com.apple.servicemanagement_rules_item_ruletype",
-                        "settingInstanceTemplateReference": null,
-                        "choiceSettingValue": {
-                          "settingValueTemplateReference": null,
-                          "value": "com.apple.servicemanagement_rules_item_ruletype_2",
-                          "children": []
-                        }
-                      },
-                      {
-                        "@odata.type": "#microsoft.graph.deviceManagementConfigurationSimpleSettingInstance",
-                        "settingDefinitionId": "com.apple.servicemanagement_rules_item_rulevalue",
-                        "settingInstanceTemplateReference": null,
-                        "simpleSettingValue": {
-                          "@odata.type": "#microsoft.graph.deviceManagementConfigurationStringSettingValue",
-                          "settingValueTemplateReference": null,
-                          "value": "com.microsoft.OneDrive-mac"
                         }
                       }
                     ]
@@ -134,41 +99,6 @@
                           "@odata.type": "#microsoft.graph.deviceManagementConfigurationStringSettingValue",
                           "settingValueTemplateReference": null,
                           "value": "com.microsoft.OneDriveLauncher"
-                        }
-                      }
-                    ]
-                  },
-                  {
-                    "settingValueTemplateReference": null,
-                    "children": [
-                      {
-                        "@odata.type": "#microsoft.graph.deviceManagementConfigurationSimpleSettingInstance",
-                        "settingDefinitionId": "com.apple.servicemanagement_rules_item_comment",
-                        "settingInstanceTemplateReference": null,
-                        "simpleSettingValue": {
-                          "@odata.type": "#microsoft.graph.deviceManagementConfigurationStringSettingValue",
-                          "settingValueTemplateReference": null,
-                          "value": "SharePoint"
-                        }
-                      },
-                      {
-                        "@odata.type": "#microsoft.graph.deviceManagementConfigurationChoiceSettingInstance",
-                        "settingDefinitionId": "com.apple.servicemanagement_rules_item_ruletype",
-                        "settingInstanceTemplateReference": null,
-                        "choiceSettingValue": {
-                          "settingValueTemplateReference": null,
-                          "value": "com.apple.servicemanagement_rules_item_ruletype_0",
-                          "children": []
-                        }
-                      },
-                      {
-                        "@odata.type": "#microsoft.graph.deviceManagementConfigurationSimpleSettingInstance",
-                        "settingDefinitionId": "com.apple.servicemanagement_rules_item_rulevalue",
-                        "settingInstanceTemplateReference": null,
-                        "simpleSettingValue": {
-                          "@odata.type": "#microsoft.graph.deviceManagementConfigurationStringSettingValue",
-                          "settingValueTemplateReference": null,
-                          "value": "com-microsoft.SharePoint-mac"
                         }
                       }
                     ]
@@ -267,71 +197,6 @@
                                 }
                               }
                             ]
-                          },
-                          {
-                            "settingValueTemplateReference": null,
-                            "children": [
-                              {
-                                "@odata.type": "#microsoft.graph.deviceManagementConfigurationChoiceSettingInstance",
-                                "settingDefinitionId": "com.apple.tcc.configuration-profile-policy_services_systempolicyallfiles_item_allowed",
-                                "settingInstanceTemplateReference": null,
-                                "choiceSettingValue": {
-                                  "settingValueTemplateReference": null,
-                                  "value": "com.apple.tcc.configuration-profile-policy_services_systempolicyallfiles_item_allowed_true",
-                                  "children": []
-                                }
-                              },
-                              {
-                                "@odata.type": "#microsoft.graph.deviceManagementConfigurationChoiceSettingInstance",
-                                "settingDefinitionId": "com.apple.tcc.configuration-profile-policy_services_systempolicyallfiles_item_authorization",
-                                "settingInstanceTemplateReference": null,
-                                "choiceSettingValue": {
-                                  "settingValueTemplateReference": null,
-                                  "value": "com.apple.tcc.configuration-profile-policy_services_systempolicyallfiles_item_authorization_0",
-                                  "children": []
-                                }
-                              },
-                              {
-                                "@odata.type": "#microsoft.graph.deviceManagementConfigurationSimpleSettingInstance",
-                                "settingDefinitionId": "com.apple.tcc.configuration-profile-policy_services_systempolicyallfiles_item_coderequirement",
-                                "settingInstanceTemplateReference": null,
-                                "simpleSettingValue": {
-                                  "@odata.type": "#microsoft.graph.deviceManagementConfigurationStringSettingValue",
-                                  "settingValueTemplateReference": null,
-                                  "value": "identifier \\\"com.microsoft.OneDrive\\\" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = UBF8T346G9"
-                                }
-                              },
-                              {
-                                "@odata.type": "#microsoft.graph.deviceManagementConfigurationSimpleSettingInstance",
-                                "settingDefinitionId": "com.apple.tcc.configuration-profile-policy_services_systempolicyallfiles_item_identifier",
-                                "settingInstanceTemplateReference": null,
-                                "simpleSettingValue": {
-                                  "@odata.type": "#microsoft.graph.deviceManagementConfigurationStringSettingValue",
-                                  "settingValueTemplateReference": null,
-                                  "value": "com.microsoft.OneDrive-mac"
-                                }
-                              },
-                              {
-                                "@odata.type": "#microsoft.graph.deviceManagementConfigurationChoiceSettingInstance",
-                                "settingDefinitionId": "com.apple.tcc.configuration-profile-policy_services_systempolicyallfiles_item_identifiertype",
-                                "settingInstanceTemplateReference": null,
-                                "choiceSettingValue": {
-                                  "settingValueTemplateReference": null,
-                                  "value": "com.apple.tcc.configuration-profile-policy_services_systempolicyallfiles_item_identifiertype_0",
-                                  "children": []
-                                }
-                              },
-                              {
-                                "@odata.type": "#microsoft.graph.deviceManagementConfigurationChoiceSettingInstance",
-                                "settingDefinitionId": "com.apple.tcc.configuration-profile-policy_services_systempolicyallfiles_item_staticcode",
-                                "settingInstanceTemplateReference": null,
-                                "choiceSettingValue": {
-                                  "settingValueTemplateReference": null,
-                                  "value": "com.apple.tcc.configuration-profile-policy_services_systempolicyallfiles_item_staticcode_false",
-                                  "children": []
-                                }
-                              }
-                            ]
                           }
                         ]
                       }
@@ -371,11 +236,6 @@
                             "@odata.type": "#microsoft.graph.deviceManagementConfigurationStringSettingValue",
                             "settingValueTemplateReference": null,
                             "value": "com.microsoft.OneDrive.FinderSync"
-                          },
-                          {
-                            "@odata.type": "#microsoft.graph.deviceManagementConfigurationStringSettingValue",
-                            "settingValueTemplateReference": null,
-                            "value": "com.microsoft.OneDrive-mac.FinderSync"
                           }
                         ]
                       },

--- a/MACOS/NativeImport/MacOS - OIB - Microsoft OneDrive - U - Known Folder Move - v1.0.json
+++ b/MACOS/NativeImport/MacOS - OIB - Microsoft OneDrive - U - Known Folder Move - v1.0.json
@@ -1,16 +1,16 @@
 ﻿{
   "@odata.context": "https://graph.microsoft.com/beta/$metadata#deviceManagement/configurationPolicies/$entity",
-  "createdDateTime": "2024-08-17T14:22:25.4998253Z",
+  "createdDateTime": "2024-08-27T14:33:09.3311679Z",
   "creationSource": null,
   "description": "",
-  "lastModifiedDateTime": "2024-08-19T16:57:34.8030639Z",
-  "name": "MacOS - OIB - Microsoft OneDrive - U - Known Folder Move - v1.0",
+  "lastModifiedDateTime": "2024-08-29T12:03:07.6652218Z",
+  "name": "MacOS - OIB - Microsoft OneDrive - U - Known Folder Move - v1.1",
   "platforms": "macOS",
   "priorityMetaData": null,
   "roleScopeTagIds": ["0"],
-  "settingCount": 14,
+  "settingCount": 15,
   "technologies": "mdm,appleRemoteManagement",
-  "id": "b223d8ae-ebc9-4d96-8bf7-82ccbd7999fb",
+  "id": "a205fcca-770e-4470-a2dd-f83e61eae51b",
   "templateReference": {
     "templateId": "",
     "templateFamily": "none",
@@ -206,6 +206,19 @@
     },
     {
       "id": "13",
+      "settingInstance": {
+        "@odata.type": "#microsoft.graph.deviceManagementConfigurationChoiceSettingInstance",
+        "settingDefinitionId": "com.apple.managedclient.preferences_openatlogin",
+        "settingInstanceTemplateReference": null,
+        "choiceSettingValue": {
+          "settingValueTemplateReference": null,
+          "value": "com.apple.managedclient.preferences_openatlogin_true",
+          "children": []
+        }
+      }
+    },
+    {
+      "id": "14",
       "settingInstance": {
         "@odata.type": "#microsoft.graph.deviceManagementConfigurationSimpleSettingInstance",
         "settingDefinitionId": "com.apple.managedclient.preferences_kfmoptinwithwizard",


### PR DESCRIPTION
Hi James,

First of, I’m really impressed with the settings you’ve provided.

I’ve imported, deployed, and tested them all, and I see some opportunities for improvement. Below is my proposal for Version 1.1.

Please note, the version number in the file names must be updated after the merge.

---

### **MacOS - OIB - Microsoft OneDrive - D - Service and Access - v1.1**

**Changes:**

- **Login → Service Management - Managed Login Items:**
  - Removed 2 Rules besides OneDrive (Standalone) and Launcher. KFM is only supported for the Standalone version that is part of the M365 Apps installation. You can only run one instance of OneDrive at a time, so it doesn't make sense to manage all different versions, in my opinion.
  - Changed the Rule Type of OneDrive Standalone from `Label` to `Label Prefix`.

- **Privacy → Privacy Preferences Policy Control:**
  - Removed the identifier for `com.microsoft.OneDrive-mac`, which is the Store App that does not support KFM.

- **System Configuration → System Extension:**
  - Removed `com.microsoft.OneDrive-mac.FinderSync` from the identifier as this is not needed.

---

### **MacOS - OIB - Microsoft OneDrive - U - Known Folder Move - v1.1**

- Added the setting “Open at login” and set it to `True`. This automatically starts OneDrive after the user signs in.

---

### **MacOS - OIB - Disk Encryption - D - FileVault - v1.1**

- Added “Recovery Key Rotation In Months” and set it to `6 months`. This makes it more secure and aligns with a lot of the security baseline in enterprises (same with Bitlocker Key rotation on Windows Devices)
- Removed Defer setting as this causes problems activating it in the Setup Assistant. Despite what Microsoft Techcommunity suggests, it works better without it.

**FYI:** You need to show the FileVault screen in the Setup Assistant. This can be configured in the enrollment profile.

---

### **MacOS - OIB - Microsoft AutoUpdate - D - MAU Configuration - v1.1**

- Enabled the setting “Guard against app modification” to enable delta updates.
- Changed Update Channel from `Current Channel` to `Current Channel (Monthly)`. This is the monthly enterprise channel on Windows M365 apps.
- Changed the setting for “Updater optimization technique” from `Lower network overhead` to `Lower processor overhead`. This is because updates are only installing beta updates when Guard against app modification is enabled, and most problems users experience are related to processor performance (e.g., the device getting warmer and slower).

---

### **MacOS - OIB - Microsoft Office - D - Updates - v1.0**
- I think we can delete this.
- **Policy not needed** as those apps are getting auto-registered into MAU. 
- Only necessary if using different update channels for these apps, but generally not advised. The **MAU Configuration - v1.0 is perfectly fine.**

---

### **MacOS - OIB - Defender Antivirus - D - Antivirus Configuration - v1.1**

- Changed the setting “Show / hide status menu icon” from `enabled` to `disabled`: Set to `disabled` so the icon is displayed in the menu bar, allowing users to see the status and manually force updates if needed. **Key is `hideStatusMenuIcon`, so `disable` (default) shows the icon in the menubar.**

---

### **MacOS - OIB - Firewall - D - Gatekeeper - v1.1**

- Changed the setting “Allow Identified Developers” (Gatekeeper) from `false` to `true`: Some apps are installed with scripts, like Company Portal and M365. Setting "Allow Identified Developers" to `false` means only Apps from the App Store are allowed.
- Changed the setting “Block all incoming” (Firewall) from `true` to `false`. This prevents connection issues with devices on the same network, e.g., AirPrint, headphones, and external displays or TVs.

---

### **MacOS - OIB - Device Security - D - Accounts and Login - v1.1**

- Changed the setting “Hide Admin Users” from `true` to `false`: Setting "Hide Admin Users" to `true` is super annoying. Most users are still local admins on their macOS devices, and when trying to log in, the username is not pre-filled, requiring manual entry on the login screen.
