### PR TITLE
Update Win - OIB - Compliance - U - Device Security - v3.1.json

### DIFF
--- a/WINDOWS/IntuneManagement/CompliancePolicies/Win - OIB - Compliance - U - Device Security - v3.1.json
+++ b/WINDOWS/IntuneManagement/CompliancePolicies/Win - OIB - Compliance - U - Device Security - v3.1.json
@@ -38,7 +38,7 @@
     "kernelDmaProtectionEnabled":  false,
     "virtualizationBasedSecurityEnabled":  false,
     "firmwareProtectionEnabled":  false,
-    "storageRequireEncryption":  false,
+    "storageRequireEncryption":  true,
     "activeFirewallRequired":  true,
     "defenderEnabled":  false,
     "defenderVersion":  null,


### PR DESCRIPTION
Can we change storageRequireEncryption from False to True

This setting Require encryption on windows devices, in addition to the bitlocker function in the compliance policy which "Require devices to be reported healthy by Windows Device Health Attestation - bit locker is enabled" only checks whether bitlocker is enabled

https://learn.microsoft.com/en-us/graph/api/resources/intune-deviceconfig-windows10compliancepolicy?view=graph-rest-1.0

