### PR TITLE
Adding deprecated reason to description

### DIFF
--- a/WINDOWS/IntuneManagement/SettingsCatalog/Win - OIB - SC - Google Chrome - D - Security - v3.0 (Deprecated).json
+++ b/WINDOWS/IntuneManagement/SettingsCatalog/Win - OIB - SC - Google Chrome - D - Security - v3.0 (Deprecated).json
@@ -6,7 +6,7 @@
     "createdDateTime@odata.type":  "#DateTimeOffset",
     "createdDateTime":  "2023-08-09T15:01:31.4711247Z",
     "creationSource":  null,
-    "description":  "",
+    "description":  "Maintaining a level of parity between Edge and Chrome is difficult, and the OIB Chrome policies were (on purpose) very 'Anti Chrome'. My focus will be to ensure the best set of policies for Edge moving forward, and dropping the Chrome policies. It is my opinion that Edge should be the primary and only browser available in an enterprise environment, and continued efforts by Microsoft to improve the security and managability of Edge for Business backs this up. My recommendation is to use the Edge Management Service to Block other Browsers(https://learn.microsoft.com/en-us/deployedge/microsoft-edge-management-service-customizations#block-other-browsers) which creates and deploys an AppLocker policy to block the installation or execution of other browsers on corporate devices.",
     "lastModifiedDateTime@odata.type":  "#DateTimeOffset",
     "lastModifiedDateTime":  "2024-12-05T20:09:18.070481Z",
     "name":  "Win - OIB - SC - Google Chrome - D - Security - v3.0 (Deprecated)",

--- a/WINDOWS/IntuneManagement/SettingsCatalog/Win - OIB - SC - Google Chrome - U - Experience and Extensions - v3.0 (Deprecated).json
+++ b/WINDOWS/IntuneManagement/SettingsCatalog/Win - OIB - SC - Google Chrome - U - Experience and Extensions - v3.0 (Deprecated).json
@@ -6,7 +6,7 @@
     "createdDateTime@odata.type":  "#DateTimeOffset",
     "createdDateTime":  "2023-08-09T15:01:32.1307904Z",
     "creationSource":  null,
-    "description":  "",
+    "description":  "Maintaining a level of parity between Edge and Chrome is difficult, and the OIB Chrome policies were (on purpose) very 'Anti Chrome'. My focus will be to ensure the best set of policies for Edge moving forward, and dropping the Chrome policies. It is my opinion that Edge should be the primary and only browser available in an enterprise environment, and continued efforts by Microsoft to improve the security and managability of Edge for Business backs this up. My recommendation is to use the Edge Management Service to Block other Browsers(https://learn.microsoft.com/en-us/deployedge/microsoft-edge-management-service-customizations#block-other-browsers) which creates and deploys an AppLocker policy to block the installation or execution of other browsers on corporate devices.",
     "lastModifiedDateTime@odata.type":  "#DateTimeOffset",
     "lastModifiedDateTime":  "2024-12-05T20:09:34.8991696Z",
     "name":  "Win - OIB - SC - Google Chrome - U - Experience and Extensions - v3.0 (Deprecated)",

--- a/WINDOWS/IntuneManagement/SettingsCatalog/Win - OIB - SC - Google Chrome - U - Profiles, Sign-In and Sync - v3.0 (Deprecated).json
+++ b/WINDOWS/IntuneManagement/SettingsCatalog/Win - OIB - SC - Google Chrome - U - Profiles, Sign-In and Sync - v3.0 (Deprecated).json
@@ -6,7 +6,7 @@
     "createdDateTime@odata.type":  "#DateTimeOffset",
     "createdDateTime":  "2023-08-09T15:01:32.9198892Z",
     "creationSource":  null,
-    "description":  "",
+    "description":  "Maintaining a level of parity between Edge and Chrome is difficult, and the OIB Chrome policies were (on purpose) very 'Anti Chrome'. My focus will be to ensure the best set of policies for Edge moving forward, and dropping the Chrome policies. It is my opinion that Edge should be the primary and only browser available in an enterprise environment, and continued efforts by Microsoft to improve the security and managability of Edge for Business backs this up. My recommendation is to use the Edge Management Service to Block other Browsers(https://learn.microsoft.com/en-us/deployedge/microsoft-edge-management-service-customizations#block-other-browsers) which creates and deploys an AppLocker policy to block the installation or execution of other browsers on corporate devices.",
     "lastModifiedDateTime@odata.type":  "#DateTimeOffset",
     "lastModifiedDateTime":  "2024-12-05T20:09:49.8021979Z",
     "name":  "Win - OIB - SC - Google Chrome - U - Profiles, Sign-In and Sync - v3.0 (Deprecated)",


### PR DESCRIPTION
I have just dumped these policies onto a test tenant and was looking at them via Intune rather than IntuneManagement and couldn't seem to work out the reason for the Google Chrome policies being deprecated. 

After searching all of the repo to work out when they were deprecated would it be possible to add it to the description until these policies are removed from the repo.

[Officially deprecated in v3.4](https://github.com/SkipToTheEndpoint/OpenIntuneBaseline/blob/main/WINDOWS/CHANGELOG.md#settings-catalog-4) 