### PR TITLE
MacOS: Remove deprecated OneDrive "Open at login" setting; add script-based replacement

### DIFF
--- a/MACOS/CHANGELOG.md
+++ b/MACOS/CHANGELOG.md
@@ -1,5 +1,19 @@
 # OIB MacOS Change Log
 
+# MacOS v1.1 - 2026-07-14
+
+## Added
+### Scripts
+**Enable-OneDriveOpenAtLogin** (suggested policy name: `MacOS - OIB - Microsoft OneDrive - U - Open at Login - v1.1`)
+* New user-context shell script (in the new `MACOS/Scripts` folder) that enables the OneDrive login item via OneDrive's `/createloginitem` command (OneDrive 26.027+), replacing the removed "Open at login" setting below. The script is idempotent: it no-ops until OneDrive >= 26.027 is installed, performs the enable exactly once, then a per-user marker keeps every later run a no-op. It works together with the Managed Login Items in "MacOS - OIB - Microsoft OneDrive - D - Service and Access", which allow and lock the login item but cannot enable it. See `MACOS/Scripts/README.md` for deployment settings. Adapted from [microsoft/intune-my-macs PR #39](https://github.com/microsoft/intune-my-macs/pull/39).
+
+## Changed/Updated
+### Settings Catalog
+**MacOS - OIB - Microsoft OneDrive - U - Known Folder Move** (v1.0 → v1.1)
+* Removed the setting "Open at login". The underlying `OpenAtLogin` managed preference is deprecated and has been a no-op since OneDrive sync app 24.113, so the policy was silently doing nothing for this setting. A Managed Login Items payload can't replace it either, as it can only allow/lock a login item, not enable one. OneDrive start-at-login is now handled by the new `Enable-OneDriveOpenAtLogin` script above.
+
+---
+
 # MacOS v1.0 Release - 2024-09-02
 As per PR [#35](https://github.com/SkipToTheEndpoint/OpenIntuneBaseline/pull/35) by @ugurkocde
 

--- a/MACOS/IntuneManagement/SettingsCatalog/MacOS - OIB - Microsoft OneDrive - U - Known Folder Move - v1.1.json
+++ b/MACOS/IntuneManagement/SettingsCatalog/MacOS - OIB - Microsoft OneDrive - U - Known Folder Move - v1.1.json
@@ -9,7 +9,7 @@
     "description":  "",
     "lastModifiedDateTime@odata.type":  "#DateTimeOffset",
     "lastModifiedDateTime":  "2024-08-30T10:17:13.6247849Z",
-    "name":  "MacOS - OIB - Microsoft OneDrive - U - Known Folder Move - v1.0",
+    "name":  "MacOS - OIB - Microsoft OneDrive - U - Known Folder Move - v1.1",
     "platforms@odata.type":  "#microsoft.graph.deviceManagementConfigurationPlatforms",
     "platforms":  "macOS",
     "priorityMetaData":  null,
@@ -17,7 +17,7 @@
     "roleScopeTagIds":  [
                             "0"
                         ],
-    "settingCount":  15,
+    "settingCount":  14,
     "technologies@odata.type":  "#microsoft.graph.deviceManagementConfigurationTechnologies",
     "technologies":  "mdm,appleRemoteManagement",
     "id":  "1ca2dd46-7a65-4006-aee0-9d1ab134f7d9",
@@ -341,28 +341,6 @@
                          "@odata.editLink":  "deviceManagement/configurationPolicies(\u00271ca2dd46-7a65-4006-aee0-9d1ab134f7d9\u0027)/settings(\u002713\u0027)",
                          "id":  "13",
                          "settingInstance":  {
-                                                 "@odata.type":  "#microsoft.graph.deviceManagementConfigurationChoiceSettingInstance",
-                                                 "settingDefinitionId":  "com.apple.managedclient.preferences_openatlogin",
-                                                 "settingInstanceTemplateReference":  null,
-                                                 "choiceSettingValue":  {
-                                                                            "@odata.type":  "#microsoft.graph.deviceManagementConfigurationChoiceSettingValue",
-                                                                            "settingValueTemplateReference":  null,
-                                                                            "value":  "com.apple.managedclient.preferences_openatlogin_true",
-                                                                            "children@odata.type":  "#Collection(microsoft.graph.deviceManagementConfigurationSettingInstance)",
-                                                                            "children":  [
-
-                                                                                         ]
-                                                                        }
-                                             },
-                         "settingDefinitions@odata.associationLink":  "https://graph.microsoft.com/beta/deviceManagement/configurationPolicies(\u00271ca2dd46-7a65-4006-aee0-9d1ab134f7d9\u0027)/settings(\u002713\u0027)/settingDefinitions/$ref",
-                         "settingDefinitions@odata.navigationLink":  "https://graph.microsoft.com/beta/deviceManagement/configurationPolicies(\u00271ca2dd46-7a65-4006-aee0-9d1ab134f7d9\u0027)/settings(\u002713\u0027)/settingDefinitions"
-                     },
-                     {
-                         "@odata.type":  "#microsoft.graph.deviceManagementConfigurationSetting",
-                         "@odata.id":  "deviceManagement/configurationPolicies(\u00271ca2dd46-7a65-4006-aee0-9d1ab134f7d9\u0027)/settings(\u002714\u0027)",
-                         "@odata.editLink":  "deviceManagement/configurationPolicies(\u00271ca2dd46-7a65-4006-aee0-9d1ab134f7d9\u0027)/settings(\u002714\u0027)",
-                         "id":  "14",
-                         "settingInstance":  {
                                                  "@odata.type":  "#microsoft.graph.deviceManagementConfigurationSimpleSettingInstance",
                                                  "settingDefinitionId":  "com.apple.managedclient.preferences_kfmoptinwithwizard",
                                                  "settingInstanceTemplateReference":  null,
@@ -372,8 +350,8 @@
                                                                             "value":  "%OrganizationId%"
                                                                         }
                                              },
-                         "settingDefinitions@odata.associationLink":  "https://graph.microsoft.com/beta/deviceManagement/configurationPolicies(\u00271ca2dd46-7a65-4006-aee0-9d1ab134f7d9\u0027)/settings(\u002714\u0027)/settingDefinitions/$ref",
-                         "settingDefinitions@odata.navigationLink":  "https://graph.microsoft.com/beta/deviceManagement/configurationPolicies(\u00271ca2dd46-7a65-4006-aee0-9d1ab134f7d9\u0027)/settings(\u002714\u0027)/settingDefinitions"
+                         "settingDefinitions@odata.associationLink":  "https://graph.microsoft.com/beta/deviceManagement/configurationPolicies(\u00271ca2dd46-7a65-4006-aee0-9d1ab134f7d9\u0027)/settings(\u002713\u0027)/settingDefinitions/$ref",
+                         "settingDefinitions@odata.navigationLink":  "https://graph.microsoft.com/beta/deviceManagement/configurationPolicies(\u00271ca2dd46-7a65-4006-aee0-9d1ab134f7d9\u0027)/settings(\u002713\u0027)/settingDefinitions"
                      }
                  ],
     "#microsoft.graph.assign":  {

--- a/MACOS/NativeImport/MacOS - OIB - Microsoft OneDrive - U - Known Folder Move - v1.1.json
+++ b/MACOS/NativeImport/MacOS - OIB - Microsoft OneDrive - U - Known Folder Move - v1.1.json
@@ -4,11 +4,11 @@
   "creationSource": null,
   "description": "",
   "lastModifiedDateTime": "2024-08-29T12:03:07.6652218Z",
-  "name": "MacOS - OIB - Microsoft OneDrive - U - Known Folder Move - v1.0",
+  "name": "MacOS - OIB - Microsoft OneDrive - U - Known Folder Move - v1.1",
   "platforms": "macOS",
   "priorityMetaData": null,
   "roleScopeTagIds": ["0"],
-  "settingCount": 15,
+  "settingCount": 14,
   "technologies": "mdm,appleRemoteManagement",
   "id": "a205fcca-770e-4470-a2dd-f83e61eae51b",
   "templateReference": {
@@ -206,19 +206,6 @@
     },
     {
       "id": "13",
-      "settingInstance": {
-        "@odata.type": "#microsoft.graph.deviceManagementConfigurationChoiceSettingInstance",
-        "settingDefinitionId": "com.apple.managedclient.preferences_openatlogin",
-        "settingInstanceTemplateReference": null,
-        "choiceSettingValue": {
-          "settingValueTemplateReference": null,
-          "value": "com.apple.managedclient.preferences_openatlogin_true",
-          "children": []
-        }
-      }
-    },
-    {
-      "id": "14",
       "settingInstance": {
         "@odata.type": "#microsoft.graph.deviceManagementConfigurationSimpleSettingInstance",
         "settingDefinitionId": "com.apple.managedclient.preferences_kfmoptinwithwizard",

--- a/MACOS/SETTINGSOUTPUT.md
+++ b/MACOS/SETTINGSOUTPUT.md
@@ -42,7 +42,7 @@
 
     - [MacOS - OIB - Microsoft OneDrive - D - Service and Access - v1.0](#section-17)
 
-    - [MacOS - OIB - Microsoft OneDrive - U - Known Folder Move - v1.0](#section-18)
+    - [MacOS - OIB - Microsoft OneDrive - U - Known Folder Move - v1.1](#section-18)
 
     - [MacOS - OIB - Updates - D - Update Configuration - v1.0](#section-19)
 
@@ -1971,7 +1971,7 @@
 ###### Table 30. Settings - MacOS - OIB - Microsoft OneDrive - D - Service and Access - v1.0
 
 
-<h3 id="section-18">MacOS - OIB - Microsoft OneDrive - U - Known Folder Move - v1.0</h3>
+<h3 id="section-18">MacOS - OIB - Microsoft OneDrive - U - Known Folder Move - v1.1</h3>
 
 <table class='table-settings'>
 <tr class='table-header1'>
@@ -1983,7 +1983,7 @@
 </tr>
 <tr class=''>
 <td class='property-column1'>Name</td>
-<td class='property-column2'>MacOS - OIB - Microsoft OneDrive - U - Known Folder Move - v1.0</td>
+<td class='property-column2'>MacOS - OIB - Microsoft OneDrive - U - Known Folder Move - v1.1</td>
 </tr>
 <tr class=''>
 <td class='property-column1'>Description</td>
@@ -2011,7 +2011,7 @@
 </tr>
 </table>
 
-###### Table 31. Basics - MacOS - OIB - Microsoft OneDrive - U - Known Folder Move - v1.0
+###### Table 31. Basics - MacOS - OIB - Microsoft OneDrive - U - Known Folder Move - v1.1
 
 
 <table class='table-settings'>
@@ -2072,16 +2072,12 @@
 <td class='property-column2'>True</td>
 </tr>
 <tr class=''>
-<td class='property-column1'>Open at login</td>
-<td class='property-column2'>True</td>
-</tr>
-<tr class=''>
 <td class='property-column1'>Prompt users to enable the Folder Backup feature (Known Folder Move)</td>
 <td class='property-column2'>%OrganizationId%</td>
 </tr>
 </table>
 
-###### Table 32. Settings - MacOS - OIB - Microsoft OneDrive - U - Known Folder Move - v1.0
+###### Table 32. Settings - MacOS - OIB - Microsoft OneDrive - U - Known Folder Move - v1.1
 
 
 <h3 id="section-19">MacOS - OIB - Updates - D - Update Configuration - v1.0</h3>

--- a/MACOS/Scripts/Enable-OneDriveOpenAtLogin.zsh
+++ b/MACOS/Scripts/Enable-OneDriveOpenAtLogin.zsh
@@ -1,0 +1,57 @@
+#!/bin/zsh
+############################################################################################
+##
+## MacOS - OIB - Microsoft OneDrive - U - Open at Login
+##
+## Enables the OneDrive login item via OneDrive's /createloginitem command (26.027+)
+## so OneDrive launches automatically at login for the signed-in user. Needed because
+## the legacy OpenAtLogin preference is deprecated (a no-op since sync app 24.113) and
+## the Managed Login Items in "MacOS - OIB - Microsoft OneDrive - D - Service and Access"
+## can only allow/lock a login item, not enable it.
+##
+## Adapted from microsoft/intune-my-macs PR #39 (MIT License,
+## Copyright (c) Microsoft Corporation).
+##
+## Requirements:
+##   - Run script as signed-in user = Yes (open -a fails outside the user's Aqua session)
+##   - Execution frequency = every 15 min; idempotent - no-ops until OneDrive >= 26.027
+##     is installed, runs the enable once, then a per-user marker keeps runs a no-op.
+##
+############################################################################################
+
+set -u
+ONEDRIVE="/Applications/OneDrive.app"
+MINVER="26.027"   # first OneDrive build supporting /createloginitem
+MARKER="$HOME/Library/Application Support/OpenIntuneBaseline/onedrive-loginitem.done"
+
+log() { echo "[onedrive-openatlogin] $*"; }
+
+# Guard 0 - already registered on this account; keeps the 15-min cadence a cheap
+# no-op that never re-launches OneDrive. Delete the marker file to force a re-run.
+if [[ -f "$MARKER" ]]; then
+  log "Login item already registered (marker present) - no-op."
+  exit 0
+fi
+
+# Guard 1 - no-op until OneDrive is installed (the app install may lag this script).
+if [[ ! -d "$ONEDRIVE" ]]; then
+  log "OneDrive not installed yet - no-op; will retry next run."
+  exit 0
+fi
+
+# Guard 2 - /createloginitem needs OneDrive >= 26.027. Older builds still honour
+# the OpenAtLogin managed pref, so just no-op rather than launching the full app.
+ver=$(defaults read "$ONEDRIVE/Contents/Info" CFBundleShortVersionString 2>/dev/null || echo "0")
+ok=$(awk -v v="$ver" -v m="$MINVER" 'BEGIN{split(v,a,".");split(m,b,".");print (a[1]*100000+a[2] >= b[1]*100000+b[2])?1:0}')
+if [[ "$ok" != "1" ]]; then
+  log "OneDrive $ver < $MINVER - /createloginitem unavailable; relying on OpenAtLogin pref. No-op."
+  exit 0
+fi
+
+# Enable the OneDrive login item. Fire-and-exit; does not launch the full sync
+# client. Then drop the marker so Guard 0 no-ops every subsequent run.
+open -a "$ONEDRIVE" --args /createloginitem
+mkdir -p "${MARKER:h}"
+print -r -- "registered OneDrive $ver at login" > "$MARKER"
+log "Requested OneDrive login-item registration (OneDrive $ver); marker written."
+exit 0

--- a/MACOS/Scripts/README.md
+++ b/MACOS/Scripts/README.md
@@ -1,0 +1,21 @@
+# Scripts
+
+This folder contains scripts that supplement the MacOS OIB where a Settings Catalog policy cannot achieve the desired result.
+
+## Enable-OneDriveOpenAtLogin
+### Purpose
+The OneDrive "Open at login" (`OpenAtLogin`) managed preference is deprecated and has been a no-op since sync app 24.113, so configuring it via Settings Catalog silently does nothing. A Managed Login Items payload can't replace it either: per Apple, Managed Login Items only *allow*/lock a login item, they never *enable* one. The only supported mechanism is OneDrive's own `/createloginitem` fire-and-exit command (OneDrive 26.027+), which must run as the signed-in user.
+
+This script enables the OneDrive login item via `/createloginitem` so OneDrive starts automatically after the user signs in. It is guarded and idempotent: it no-ops until OneDrive >= 26.027 is installed, performs the enable exactly once, then a per-user marker file keeps every later run a no-op so the recurring schedule never re-launches OneDrive.
+
+It works together with the Managed Login Items configured in `MacOS - OIB - Microsoft OneDrive - D - Service and Access`: the script enables the login item, the policy keeps it allowed and locked on.
+
+### Usage
+**Script type** - Shell script (macOS)
+**Suggested name** - `MacOS - OIB - Microsoft OneDrive - U - Open at Login - v1.1`
+**Assign to** - Users
+**Script Settings:**
+- Run script as signed-in user - Yes
+- Hide script notifications on devices - Yes
+- Script frequency - Every 15 minutes
+- Max number of times to retry if script fails - 3


### PR DESCRIPTION
## Summary

The OneDrive `OpenAtLogin` managed preference is deprecated and has been a no-op since sync app 24.113, so the "Open at login" setting in `MacOS - OIB - Microsoft OneDrive - U - Known Folder Move` (added in the v1.0 release) has been silently doing nothing. A Managed Login Items payload can't replace it either: per Apple, Managed Login Items only *allow*/lock a login item, they never *enable* one. The only supported mechanism is OneDrive's own `/createloginitem` fire-and-exit command (OneDrive 26.027+), which must run as the signed-in user.

The same issue I recently fixed in microsoft/intune-my-macs ([microsoft/intune-my-macs#39](https://github.com/microsoft/intune-my-macs/pull/39)); this PR ports that fix to the OIB.

## Changes

**MacOS - OIB - Microsoft OneDrive - U - Known Folder Move** → bumped to **v1.1**
- Removed the deprecated "Open at login" setting from both the `IntuneManagement` and `NativeImport` exports
- Setting IDs renumbered to stay contiguous, `settingCount` 15 → 14
- File encodings preserved (UTF-16 LE for the IntuneManagement export, UTF-8 BOM/CRLF for NativeImport)

**New `MACOS/Scripts` folder** (mirroring `WINDOWS/Scripts`, first macOS script in the repo)
- `Enable-OneDriveOpenAtLogin.zsh`: user-context script that enables the OneDrive login item via `/createloginitem`. Guarded and idempotent: no-ops until OneDrive ≥ 26.027 is installed, performs the enable exactly once, then a per-user marker keeps every later run a no-op so the 15-minute cadence never re-launches OneDrive. Adapted from the MIT-licensed script in the intune-my-macs PR above (attribution in the header).
- `README.md` documenting purpose and deployment settings (suggested policy name `MacOS - OIB - Microsoft OneDrive - U - Open at Login - v1.1`, assign to users, run as signed-in user, hide notifications, every 15 minutes, 3 retries)
- Works together with the Managed Login Items in `MacOS - OIB - Microsoft OneDrive - D - Service and Access`: the script enables the login item, the policy keeps it allowed and locked on

**Documentation**
- `MACOS/CHANGELOG.md`: new v1.1 section documenting the removal and the new script
- `MACOS/SETTINGSOUTPUT.md`: removed the "Open at login" row and updated the policy name references to v1.1

## Validation

- Both policy JSONs still parse, setting IDs are contiguous and 0-based
- `./Scripts/Update-OIBManifest.ps1 -Mode Validate -Platform All` passes locally
- Script behaviour verified upstream in microsoft/intune-my-macs#39 (flips the OneDriveLauncher BTM item from disabled → enabled/allowed and persists across reboots)